### PR TITLE
add function for cross-platform "readlink -f"

### DIFF
--- a/KronaTools/updateTaxonomy.sh
+++ b/KronaTools/updateTaxonomy.sh
@@ -16,7 +16,9 @@ fi
 # This would not resolve symlink:
 # ktPath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 # Therefore this:
-ktPath=$(dirname $(readlink -f $0))
+# perl function to resolve symlinks that will function on Linux and OSX (since 'readlink -f' is different under OSX)
+readlink_f(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+ktPath=$(dirname $(readlink_f $0))
 
 makefileAcc2taxid="scripts/accession2taxid.make"
 makefileTaxonomy="scripts/taxonomy.make"


### PR DESCRIPTION
Followup PR to #35; the `-f` option has a different meaning under the OSX `readlink`, so the script will fail when `-f` is used on OSX. This adds a shell script function to mimmic `readlink -f` functionality. It relies on perl, which is already a dependency of Krona.

Related to this: It would be helpful to tag a new maintenance release or minor version to ensure compatibility with OSX downstream. In bioconda, [we're patching krona](https://github.com/bioconda/bioconda-recipes/pull/3806) to have this change, but it would be better to simply rely on a newer tagged version of Krona.