### PR TITLE
Call tput only if $TERM is set.

### DIFF
--- a/KronaTools/lib/KronaTools.pm
+++ b/KronaTools/lib/KronaTools.pm
@@ -276,7 +276,15 @@ my $fileTaxonomy = 'taxonomy.tab';
 my $fileTaxByAcc = 'all.accession2taxid.sorted';
 my $memberLimitDataset = 10000;
 my $memberLimitTotal = 100000;
-my $columns = `tput cols`;
+my $columns;
+if (defined($ENV{TERM}))
+{
+	$columns = `tput cols`;
+}
+else
+{
+	$columns = 80;
+}
 our $minEVal = -450;
 
 


### PR DESCRIPTION
This resolves an issue we encountered when running ktImportGalaxy in a galaxy environment where $TERM was unset. This would result in `tput: No value for $TERM and no -T specified` being sent to standard error, resulting in the tool incorrectly detecting an error condition.