### PR TITLE
quick fix for Issue #104 (new valid NCBI accessions were discarded as "invalid")

### DIFF
--- a/KronaTools/lib/KronaTools.pm
+++ b/KronaTools/lib/KronaTools.pm
@@ -1122,7 +1122,7 @@ sub getAccFromSeqID
 	if ( $acc !~ /^\d+$/ && $acc !~ /^[A-Z\d]+_?[A-Z\d]+(\.\d+)?$/ )
 	{
 		$invalidAccs{$acc} = 1;
-		return undef;
+		#return undef;
 	}
 	
 	return $acc;
@@ -1667,7 +1667,7 @@ sub printWarnings
 	{
 		ktWarn
 		(
-			"The following accessions were not in a valid format and were ignored:\n" .
+			"The following accessions look strange and may yield erroneous results. Please check if they are acual valid NCBI accessions:\n" .
 			join ' ', (keys %invalidAccs)
 		);
 		


### PR DESCRIPTION
A quick fix for Issue #104

When confronted with a "strange" accession, ```KronaTools.pm``` no longer completely ignores the accession, but tries to look it up anyway. It simply gives a warning to the user that this accession looked strange (placing the final  responsibility on checking the input & results on the user) while still enabling the classification of many novel sequences.

As mentioned in #104, NCBI seems to have changed its rules for the Format of accessions. Many new valid accessions were now being discarded by ```ktGetLCA``` and ```ktClassifyBlast```.

However these ARE the official accessions you get as resulting Subject-ID when blasting against NCBI nr. Furthermore these accessions are indexed in ```all.accession2taxid.sorted``` (if recently updated), they were simply being ignored.