### PR TITLE
avoid conflicts with other taxonomy-based tools and keep script names consistent (also create taxonomy-directory during installation if not already existing)

### DIFF
--- a/KronaTools/install.pl
+++ b/KronaTools/install.pl
@@ -35,6 +35,7 @@ if ( defined $taxonomyDir )
 }
 
 my $scriptPath = abs_path('scripts');
+my $currentPath = abs_path('.');
 
 createDir($path);
 createDir("$path/bin");
@@ -74,11 +75,24 @@ foreach my $script
 	}
 }
 
+foreach my $script
+(qw(
+	updateTaxonomy
+	updateAccessions
+))
+{
+	if ( system('ln', '-sf', "$currentPath/$script.sh", "$path/bin/kt$script") )
+	{
+		linkFail("$path/bin");
+	}
+}
+
 if ( defined $taxonomyDir )
 {
 	if ( ! -e $taxonomyDir )
 	{
-		ktDie("$taxonomyDir does not exist.");
+		print "\n $taxonomyDir does not exist. --> creating it.\n";
+		createDir("$taxonomyDir");
 	}
 	
 	if ( -e 'taxonomy')
@@ -89,11 +103,14 @@ if ( defined $taxonomyDir )
 	print "Linking taxonomy to $taxonomyDir...\n";
 	system('ln -s -f -F ' . $taxonomyDir . ' taxonomy');
 }
-
+else
+{
+	createDir("$currentPath/taxonomy");
+}
 print '
 Installation complete.
 
-Run ./updateTaxonomy.sh to use scripts that rely on NCBI taxonomy:
+Run ktupdateTaxonomy to use scripts that rely on NCBI taxonomy:
    ktClassifyBLAST
    ktGetLCA
    ktGetTaxInfo
@@ -101,7 +118,7 @@ Run ./updateTaxonomy.sh to use scripts that rely on NCBI taxonomy:
    ktImportTaxonomy
    ktImportMETAREP-BLAST
 
-Run ./updateAccessions.sh to use scripts that get taxonomy IDs from accessions:
+Run ktupdateAccessions to use scripts that get taxonomy IDs from accessions:
    ktClassifyBLAST
    ktGetTaxIDFromAcc
    ktImportBLAST

--- a/KronaTools/lib/KronaTools.pm
+++ b/KronaTools/lib/KronaTools.pm
@@ -1229,7 +1229,7 @@ sub getTaxInfo
 	
 	if ( ! open TAX, "<$options{'taxonomy'}/$fileTaxonomy" )
 	{
-		print "ERROR: Taxonomy not found in $options{'taxonomy'}. Was updateTaxonomy.sh run?\n";
+		print "ERROR: Taxonomy not found in $options{'taxonomy'}. Was ktupdateTaxonomy run?\n";
 		exit 1;
 	}
 	
@@ -1348,7 +1348,7 @@ sub getTaxIDFromAcc
 	
 	if ( ! open ACC, "<$options{'taxonomy'}/$fileTaxByAcc" )
 	{
-		print "ERROR: Sorted accession to taxID list not found. Was updateAccessions.sh run?\n";
+		print "ERROR: Sorted accession to taxID list not found. Was ktupdateAccessions run?\n";
 		exit 1;
 	}
 	
@@ -1527,7 +1527,7 @@ sub loadMagnitudes
 sub loadTaxonomy
 {
 	open INFO, "<$options{'taxonomy'}/$fileTaxonomy" or die
-		"Taxonomy not found in $options{'taxonomy'}. Was updateTaxonomy.sh run?";
+		"Taxonomy not found in $options{'taxonomy'}. Was ktupdateTaxonomy run?";
 	
 	while ( my $line = <INFO> )
 	{
@@ -1545,7 +1545,7 @@ sub loadTaxonomy
 		ktDie
 		(
 "Local taxonomy database is out of date and does not support the
--$optionFormats{'noRank'} option. Update using updateTaxonomy.sh."
+-$optionFormats{'noRank'} option. Update using ktupdateTaxonomy."
 		);
 	}
 	close INFO;
@@ -1678,7 +1678,7 @@ sub printWarnings
 	{
 		ktWarn
 		(
-			"The following accessions were not found in the local database (if they were recently added to NCBI, use updateAccessions.sh to update the local database):\n" .
+			"The following accessions were not found in the local database (if they were recently added to NCBI, use ktupdateAccessions to update the local database):\n" .
 			join ' ', (keys %missingAccs)
 		);
 		
@@ -1689,7 +1689,7 @@ sub printWarnings
 	{
 		ktWarn
 		(
-			"The following taxonomy IDs were not found in the local database and were set to root (if they were recently added to NCBI, use updateTaxonomy.sh to update the local database):\n" .
+			"The following taxonomy IDs were not found in the local database and were set to root (if they were recently added to NCBI, use ktupdateTaxonomy to update the local database):\n" .
 			join ' ', (keys %missingTaxIDs)
 		);
 		

--- a/KronaTools/updateAccessions.sh
+++ b/KronaTools/updateAccessions.sh
@@ -6,6 +6,11 @@
 #
 # See the LICENSE.txt file included with this software for license information.
 
-ktPath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# This would not resolve symlink:
+# ktPath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# Therefore this:
+# perl function to resolve symlinks that will function on Linux and OSX (since 'readlink -f' is different under OSX)
+readlink_f(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+ktPath=$(dirname $(readlink_f $0))
 
 $ktPath/updateTaxonomy.sh --accessions $@

--- a/KronaTools/updateTaxonomy.sh
+++ b/KronaTools/updateTaxonomy.sh
@@ -20,6 +20,8 @@ fi
 readlink_f(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
 ktPath=$(dirname $(readlink_f $0))
 
+echo $ktPATH
+
 makefileAcc2taxid="scripts/accession2taxid.make"
 makefileTaxonomy="scripts/taxonomy.make"
 


### PR DESCRIPTION
```updateTaxonomy.sh``` and ```updateAccessions.sh``` would be most useful in the PATH. However their more generic name can be a problem if other taxonomy-based tools are installed and use the same naming scheme.
To fix that, the KRONA naming scheme of the perl-scripts (with "kt" prefixes) is applied to these scripts via softlinking during installation:
```updateTaxonomy.sh``` --> ```ktupdateTaxonomy```
```updateAccessions.sh``` --> ```ktupdateAccessions```
Both scripts are softlinked to the [prefix]/bin folder.

All instances mentioning the use of ```updateTaxonomy.sh``` or ```updateAccessions.sh``` in ```KronaTools.pm``` and ```install.pl``` have been corrected accordingly.